### PR TITLE
Make STXXL compile with Libc++-15

### DIFF
--- a/include/stxxl/bits/algo/ksort.h
+++ b/include/stxxl/bits/algo/ksort.h
@@ -308,11 +308,7 @@ create_runs(
 template <typename BlockType,
           typename prefetcher_type,
           typename KeyExtractor>
-struct run_cursor2_cmp : public std::binary_function<
-                             run_cursor2<BlockType, prefetcher_type>,
-                             run_cursor2<BlockType, prefetcher_type>,
-                             bool
-                             >
+struct run_cursor2_cmp
 {
     using cursor_type = run_cursor2<BlockType, prefetcher_type>;
     KeyExtractor keyobj;
@@ -336,7 +332,7 @@ private:
 };
 
 template <typename RecordType, typename KeyExtractor>
-class key_comparison : public std::binary_function<RecordType, RecordType, bool>
+class key_comparison
 {
     KeyExtractor ke;
 

--- a/include/stxxl/bits/algo/sort_helper.h
+++ b/include/stxxl/bits/algo/sort_helper.h
@@ -56,7 +56,6 @@ struct trigger_entry
 
 template <typename TriggerEntryType, typename ValueCmp>
 struct trigger_entry_cmp
-    : public std::binary_function<TriggerEntryType, TriggerEntryType, bool>
 {
     using trigger_entry_type = TriggerEntryType;
     ValueCmp cmp;
@@ -72,11 +71,6 @@ template <typename BlockType,
           typename PrefetcherType,
           typename ValueCmp>
 struct run_cursor2_cmp
-    : public std::binary_function<
-          run_cursor2<BlockType, PrefetcherType>,
-          run_cursor2<BlockType, PrefetcherType>,
-          bool
-          >
 {
     using block_type = BlockType;
     using prefetcher_type = PrefetcherType;

--- a/include/stxxl/bits/containers/btree/leaf.h
+++ b/include/stxxl/bits/containers/btree/leaf.h
@@ -72,7 +72,7 @@ public:
     using leaf_cache_type = node_cache<normal_leaf, btree_type>;
 
 public:
-    struct value_compare : public std::binary_function<value_type, value_type, bool>
+    struct value_compare
     {
         key_compare comp;
 

--- a/include/stxxl/bits/containers/btree/node.h
+++ b/include/stxxl/bits/containers/btree/node.h
@@ -76,7 +76,7 @@ public:
     using node_cache_type = node_cache<normal_node, btree_type>;
 
 private:
-    struct value_compare : public std::binary_function<value_type, value_type, bool>
+    struct value_compare
     {
         key_compare comp;
 


### PR DESCRIPTION
This is achieved by not using some features of C++ that are unneeded and delted from the standard in C++20.